### PR TITLE
Add webpack resolve config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,11 @@ module.exports = {
   },
 
   resolve: {
-    extensions: ['', '.js', '.jsx']
+    extensions: ['', '.js', '.jsx'],
+    // Tell webpack to look for required files in bower and node
+    modulesDirectories: ['bower_components', 'node_modules', 'src'],
+    fallback: ['./src']
+
   },
 
   module: {


### PR DESCRIPTION
I noticed that when trying to `require` less file in the JSX, we always use relative path, something like `../../../styles/home.less`, which is very easy to make mistakes for human beings. But we can `resolve` this pain by adding a resolver in webpack.